### PR TITLE
Add training and validation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,30 @@
 - Métricas objetivas por classe
 - Rastreabilidade de erros
 - Melhoria contínua por augmentação dirigida
+
+### Organização dos Dados
+
+Cada pasta de dataset deve conter subpastas correspondentes às seis classes
+clínicas listadas acima. Por exemplo:
+
+```
+dataset_original/
+├── Normal/
+├── Obstrução do Canal/
+├── Otite Média Aguda (OMA)/
+├── Otite Externa Aguda (OEA)/
+├── Otite Média Crônica (OMC)/
+└── Não é uma imagem otoscópica/
+```
+
+`dataset_augmented/` segue a mesma estrutura e armazena as imagens após
+processos de aumento de dados. Já `validacao/` contém o conjunto utilizado para
+avaliar o modelo.
+
+### Executando o Treinamento e a Validação
+
+1. Coloque as imagens nas pastas acima seguindo a estrutura por classes.
+2. Execute `python treinar_modelo.py` para treinar e salvar o modelo em
+   `modelo_teachable/`.
+3. Após o treinamento, rode `python avaliar_modelo.py` para gerar os relatórios
+   em `validacao/` (arquivos CSV e matriz de confusão).

--- a/avaliar_modelo.py
+++ b/avaliar_modelo.py
@@ -1,0 +1,60 @@
+import os
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+from tensorflow import keras
+from sklearn.metrics import classification_report, confusion_matrix
+
+MODEL_DIR = "modelo_teachable"
+VALID_DIR = "validacao"
+IMG_SIZE = (224, 224)
+BATCH_SIZE = 32
+
+# Gerador para ler as imagens de valida\u00e7\u00e3o
+val_datagen = ImageDataGenerator(rescale=1.0/255)
+val_generator = val_datagen.flow_from_directory(
+    VALID_DIR,
+    target_size=IMG_SIZE,
+    batch_size=BATCH_SIZE,
+    class_mode='categorical',
+    shuffle=False
+)
+
+model_path = os.path.join(MODEL_DIR, 'modelo.keras')
+model = keras.models.load_model(model_path)
+
+probs = model.predict(val_generator)
+y_pred = np.argmax(probs, axis=1)
+y_true = val_generator.classes
+labels = list(val_generator.class_indices.keys())
+
+report_dict = classification_report(
+    y_true,
+    y_pred,
+    target_names=labels,
+    output_dict=True
+)
+report_df = pd.DataFrame(report_dict).transpose()
+report_csv = os.path.join(VALID_DIR, 'relatorio_validacao.csv')
+report_df.to_csv(report_csv)
+
+pred_df = pd.DataFrame({
+    'arquivo': val_generator.filenames,
+    'classe_real': [labels[i] for i in y_true],
+    'classe_predita': [labels[i] for i in y_pred]
+})
+pred_df.to_csv(os.path.join(VALID_DIR, 'predicoes.csv'), index=False)
+
+cm = confusion_matrix(y_true, y_pred)
+plt.figure(figsize=(8, 6))
+sns.heatmap(cm, annot=True, fmt='d', cmap='Blues',
+            xticklabels=labels, yticklabels=labels)
+plt.ylabel('Real')
+plt.xlabel('Predito')
+plt.tight_layout()
+plt.savefig(os.path.join(VALID_DIR, 'matriz_confusao.png'))
+plt.close()
+
+print(f'Relat\u00f3rios salvos em {VALID_DIR}')

--- a/dataset_augmented/README.md
+++ b/dataset_augmented/README.md
@@ -1,0 +1,1 @@
+Imagens aumentadas para treinamento.

--- a/dataset_original/README.md
+++ b/dataset_original/README.md
@@ -1,0 +1,1 @@
+Coloque aqui as imagens originais organizadas por classes.

--- a/modelo_teachable/README.md
+++ b/modelo_teachable/README.md
@@ -1,0 +1,1 @@
+Modelo exportado do Teachable Images (.keras).

--- a/treinar_modelo.py
+++ b/treinar_modelo.py
@@ -1,0 +1,42 @@
+import os
+import tensorflow as tf
+
+DATASET_DIR = "dataset_augmented"
+MODEL_DIR = "modelo_teachable"
+IMG_SIZE = (224, 224)
+BATCH_SIZE = 32
+EPOCHS = 10
+
+# Carrega as imagens a partir da estrutura de pastas
+train_ds = tf.keras.utils.image_dataset_from_directory(
+    DATASET_DIR,
+    image_size=IMG_SIZE,
+    batch_size=BATCH_SIZE
+)
+
+class_names = train_ds.class_names
+num_classes = len(class_names)
+
+model = tf.keras.Sequential([
+    tf.keras.layers.Rescaling(1./255, input_shape=IMG_SIZE + (3,)),
+    tf.keras.layers.Conv2D(16, 3, activation='relu'),
+    tf.keras.layers.MaxPooling2D(),
+    tf.keras.layers.Conv2D(32, 3, activation='relu'),
+    tf.keras.layers.MaxPooling2D(),
+    tf.keras.layers.Conv2D(64, 3, activation='relu'),
+    tf.keras.layers.MaxPooling2D(),
+    tf.keras.layers.Flatten(),
+    tf.keras.layers.Dense(128, activation='relu'),
+    tf.keras.layers.Dense(num_classes)
+])
+
+model.compile(
+    optimizer='adam',
+    loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+    metrics=['accuracy']
+)
+
+model.fit(train_ds, epochs=EPOCHS)
+
+os.makedirs(MODEL_DIR, exist_ok=True)
+model.save(os.path.join(MODEL_DIR, 'modelo.keras'))

--- a/validacao/README.md
+++ b/validacao/README.md
@@ -1,0 +1,1 @@
+Coloque aqui o conjunto de validacao.


### PR DESCRIPTION
## Summary
- add instructions on dataset organization
- add skeleton training script `treinar_modelo.py`
- add evaluation script `avaliar_modelo.py`
- create dataset/model directories with placeholders

## Testing
- `python -m py_compile treinar_modelo.py avaliar_modelo.py`

------
https://chatgpt.com/codex/tasks/task_e_68855bbc3b30832bb0ddf79a6fa6552b