### PR TITLE
Add TensorFlow.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ utilizado para avaliar o modelo e armazenar os relatórios.
    `backend_validation/`.
 3. Após o treinamento, rode `python avaliar_modelo.py` para gerar os relatórios
    em `backend_validation/` (arquivos CSV e matriz de confusão).
+
+### Web Front-end
+Consulte `frontend_web/README.md` para executar a interface web que carrega o modelo TensorFlow.js e permite classificar imagens diretamente no navegador.

--- a/frontend_web/README.md
+++ b/frontend_web/README.md
@@ -1,0 +1,22 @@
+# Front-end Web Interface
+
+This folder contains a simple HTML page that allows you to load a TensorFlow.js
+model and run predictions on otoscopic images in the browser.
+
+## Files
+- `index.html` – main web page with a file input and canvas.
+- `style.css` – basic styles for the page.
+- `script.js` – JavaScript that loads the model and performs inference.
+- `model/` – place the converted TensorFlow.js model files here (`model.json`
+  and the corresponding `*.bin` weight files).
+
+## How It Works
+`script.js` uses `tf.loadLayersModel('model/model.json')` to load the model
+when the user first requests a prediction. Uploaded images are drawn to the
+canvas and converted to tensors with `tf.browser.fromPixels`. After normalizing,
+the tensor is passed to `model.predict` and the predicted class index is shown
+on screen.
+
+Simply open `index.html` in a web browser that supports JavaScript to test the
+classifier locally. Make sure the converted model files are inside the
+`model/` folder so they can be loaded.

--- a/frontend_web/index.html
+++ b/frontend_web/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Otoscopic Classifier</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.21.0/dist/tf.min.js"></script>
+</head>
+<body>
+    <h1>Otoscopic Image Classifier</h1>
+    <input type="file" id="imageUpload" accept="image/*">
+    <canvas id="preview" width="224" height="224"></canvas>
+    <button id="predictBtn">Predict</button>
+    <div id="result"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend_web/script.js
+++ b/frontend_web/script.js
@@ -1,0 +1,45 @@
+let model;
+const uploadInput = document.getElementById('imageUpload');
+const preview = document.getElementById('preview');
+const predictBtn = document.getElementById('predictBtn');
+const resultDiv = document.getElementById('result');
+
+async function loadModel() {
+    if (!model) {
+        model = await tf.loadLayersModel('model/model.json');
+    }
+}
+
+function drawImage(file) {
+    const ctx = preview.getContext('2d');
+    const reader = new FileReader();
+    reader.onload = () => {
+        const img = new Image();
+        img.onload = () => {
+            ctx.drawImage(img, 0, 0, preview.width, preview.height);
+        };
+        img.src = reader.result;
+    };
+    reader.readAsDataURL(file);
+}
+
+async function predict() {
+    await loadModel();
+    const tensor = tf.browser.fromPixels(preview)
+        .toFloat()
+        .div(255.0)
+        .expandDims();
+    const prediction = model.predict(tensor);
+    const scores = await prediction.data();
+    const classIndex = scores.indexOf(Math.max(...scores));
+    resultDiv.textContent = `Predicted class: ${classIndex}`;
+}
+
+uploadInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (file) {
+        drawImage(file);
+    }
+});
+
+predictBtn.addEventListener('click', predict);

--- a/frontend_web/style.css
+++ b/frontend_web/style.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Arial, sans-serif;
+    text-align: center;
+    padding: 20px;
+}
+
+canvas {
+    border: 1px solid #333;
+    display: block;
+    margin: 10px auto;
+}
+
+button {
+    padding: 10px 20px;
+}


### PR DESCRIPTION
## Summary
- add new `frontend_web` folder with a simple web interface
- document how to load the TensorFlow.js model and run predictions
- update README to mention the new web frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68857ad980dc832b8f2247191acf19bc