### PR TITLE
Convert model to TensorFlow.js after training

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@
 - Rastreabilidade de erros
 - Melhoria contínua por augmentação dirigida
 
+### Dependências
+
+Para treinar e converter o modelo é necessário ter instalados:
+
+```
+pip install tensorflow tensorflowjs
+```
+
 ### Organização dos Dados
 
 Cada pasta de dataset deve conter subpastas correspondentes às seis classes
@@ -48,7 +56,8 @@ utilizado para avaliar o modelo e armazenar os relatórios.
 
 1. Coloque as imagens nas pastas acima seguindo a estrutura por classes.
 2. Execute `python treinar_modelo.py` para treinar e salvar o modelo em
-   `backend_validation/`.
+   `backend_validation/`. O script também converte o modelo para o formato
+   TensorFlow.js na pasta `frontend_web/model/`.
 3. Após o treinamento, rode `python avaliar_modelo.py` para gerar os relatórios
    em `backend_validation/` (arquivos CSV e matriz de confusão).
 

--- a/treinar_modelo.py
+++ b/treinar_modelo.py
@@ -1,5 +1,6 @@
 import os
 import tensorflow as tf
+import tensorflowjs as tfjs
 
 DATASET_DIR = "dataset/augmented"
 MODEL_DIR = "backend_validation"
@@ -39,4 +40,11 @@ model.compile(
 model.fit(train_ds, epochs=EPOCHS)
 
 os.makedirs(MODEL_DIR, exist_ok=True)
-model.save(os.path.join(MODEL_DIR, 'modelo.keras'))
+keras_path = os.path.join(MODEL_DIR, 'modelo.keras')
+model.save(keras_path)
+
+# Converte o modelo salvo para TensorFlow.js
+tfjs_dir = os.path.join('frontend_web', 'model')
+os.makedirs(tfjs_dir, exist_ok=True)
+tfjs.converters.save_keras_model(model, tfjs_dir)
+print(f'Modelo salvo em {keras_path} e convertido para {tfjs_dir}')


### PR DESCRIPTION
## Summary
- convert the Keras model to TensorFlow.js format at the end of `treinar_modelo.py`
- document TensorFlow.js conversion and the `tensorflow`/`tensorflowjs` dependencies in the README

## Testing
- `python -m py_compile treinar_modelo.py avaliar_modelo.py`

------
https://chatgpt.com/codex/tasks/task_e_68857ca21dc4832ba1b99dfb67c015fd