### PR TITLE
Update evaluation output location

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ dataset/original/
 
 `dataset/augmented/` segue a mesma estrutura e armazena as imagens após
 processos de aumento de dados. Já `backend_validation/` contém o conjunto
-utilizado para avaliar o modelo e armazenar os relatórios.
+utilizado para avaliar o modelo e guardar arquivos intermediários.
+Os relatórios finais (CSV de validação e matriz de confusão) são gerados em
+`docs/`.
 
 ### Executando o Treinamento e a Validação
 
@@ -50,7 +52,8 @@ utilizado para avaliar o modelo e armazenar os relatórios.
 2. Execute `python treinar_modelo.py` para treinar e salvar o modelo em
    `backend_validation/`.
 3. Após o treinamento, rode `python avaliar_modelo.py` para gerar os relatórios
-   em `backend_validation/` (arquivos CSV e matriz de confusão).
+   em `docs/` (arquivos CSV e matriz de confusão). O arquivo `predicoes.csv`
+   permanece em `backend_validation/` para consulta detalhada.
 
 ### Web Front-end
 Consulte `frontend_web/README.md` para executar a interface web que carrega o modelo TensorFlow.js e permite classificar imagens diretamente no navegador.

--- a/avaliar_modelo.py
+++ b/avaliar_modelo.py
@@ -9,6 +9,11 @@ from sklearn.metrics import classification_report, confusion_matrix
 
 MODEL_DIR = "backend_validation"
 VALID_DIR = "backend_validation"
+DOCS_DIR = "docs"
+
+# Garantir que as pastas existam
+os.makedirs(DOCS_DIR, exist_ok=True)
+os.makedirs(VALID_DIR, exist_ok=True)
 IMG_SIZE = (224, 224)
 BATCH_SIZE = 32
 
@@ -37,7 +42,7 @@ report_dict = classification_report(
     output_dict=True
 )
 report_df = pd.DataFrame(report_dict).transpose()
-report_csv = os.path.join(VALID_DIR, 'relatorio_validacao.csv')
+report_csv = os.path.join(DOCS_DIR, 'relatorio_validacao.csv')
 report_df.to_csv(report_csv)
 
 pred_df = pd.DataFrame({
@@ -54,7 +59,7 @@ sns.heatmap(cm, annot=True, fmt='d', cmap='Blues',
 plt.ylabel('Real')
 plt.xlabel('Predito')
 plt.tight_layout()
-plt.savefig(os.path.join(VALID_DIR, 'matriz_confusao.png'))
+plt.savefig(os.path.join(DOCS_DIR, 'matriz_confusao.png'))
 plt.close()
 
-print(f'Relat\u00f3rios salvos em {VALID_DIR}')
+print(f'Relat\u00f3rios salvos em {DOCS_DIR}')


### PR DESCRIPTION
## Summary
- save `relatorio_validacao.csv` and `matriz_confusao.png` under `docs/`
- keep `predicoes.csv` in `backend_validation/`
- document the new output directory in the README
- add empty `docs/` directory for generated reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68857cb4f758832bb799e089fcce5aab