### PR TITLE
Fix preview image visibility and id usage

### DIFF
--- a/frontend_web/script.js
+++ b/frontend_web/script.js
@@ -12,8 +12,9 @@ function handleFile(event) {
   const file = event.target.files[0];
   if (!file) return;
 
-  const imgEl = document.getElementById('input-image');
+  const imgEl = document.getElementById('previewImage');
   imgEl.src = URL.createObjectURL(file);
+  imgEl.style.display = 'block';
   loadedImage = imgEl;
 
   imgEl.onload = () => URL.revokeObjectURL(imgEl.src);
@@ -21,7 +22,8 @@ function handleFile(event) {
 
 function resetView() {
   document.getElementById('imageUpload').value = '';
-  document.getElementById('input-image').src = '';
+  document.getElementById('previewImage').src = '';
+  document.getElementById('previewImage').style.display = 'none';
   document.getElementById('label-container').innerHTML = '';
   loadedImage = null;
 }


### PR DESCRIPTION
## Summary
- align preview id in `script.js` with `index.html`
- show the preview image after selecting a file
- hide the preview on reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b8438604832b9488e3eec9689e9b