### PR TITLE
Update frontend README for Teachable Machine model

### DIFF
--- a/frontend_web/README.md
+++ b/frontend_web/README.md
@@ -1,22 +1,23 @@
 # Front-end Web Interface
 
-This folder contains a simple HTML page that allows you to load a TensorFlow.js
-model and run predictions on otoscopic images in the browser.
+This folder contains a simple HTML page that allows you to load a model
+exported from Teachable Machine. The model is loaded in the browser using the
+`tmImage.load` API and can run predictions on otoscopic images.
 
 ## Files
-- `index.html` – main web page with a file input and canvas.
+ - `index.html` – main web page with a file input and a preview element
+   identified by `previewImage`.
 - `style.css` – basic styles for the page.
 - `script.js` – JavaScript that loads the model and performs inference.
-- `model/` – place the converted TensorFlow.js model files here (`model.json`
-  and the corresponding `*.bin` weight files).
+- `model/` – place the exported Teachable Machine model files here. Copy
+  `model.json`, `metadata.json` and `weights.bin` from `../modelo_teachable/`.
 
 ## How It Works
-`script.js` uses `tf.loadLayersModel('model/model.json')` to load the model
-when the user first requests a prediction. Uploaded images are drawn to the
-canvas and converted to tensors with `tf.browser.fromPixels`. After normalizing,
-the tensor is passed to `model.predict` and the predicted class index is shown
-on screen.
+`script.js` loads the model as soon as the page finishes loading using
+`tmImage.load('model/model.json', 'model/metadata.json')`. When a file is
+selected, the image is displayed inside the element with id `previewImage` and
+then passed to `model.predict` to obtain the classification probabilities.
 
-Simply open `index.html` in a web browser that supports JavaScript to test the
-classifier locally. Make sure the converted model files are inside the
-`model/` folder so they can be loaded.
+Before opening `index.html`, create the `model/` folder here and copy the files
+from `../modelo_teachable/` into it. Then simply open `index.html` in a web
+browser that supports JavaScript to test the classifier locally.


### PR DESCRIPTION
## Summary
- explain model loading via `tmImage.load`
- note preview element id `previewImage`
- add step about copying model files from `modelo_teachable` to `frontend_web/model/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b8491a54832b89772a34068676d7