### PR TITLE
Oculta seção de upload após envio e restaura no reinício

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,6 +38,7 @@ document.getElementById("imageUpload").addEventListener("change", event => {
     document.getElementById("correctionSection").classList.add("d-none");
     document.getElementById("resultado-area").classList.remove("d-none");
     document.getElementById("btn-upload").style.display = "none";
+    document.getElementById("inicio-upload").classList.add("d-none");
 
   };
   reader.readAsDataURL(file);
@@ -177,6 +178,7 @@ function reiniciar() {
   document.getElementById("clinico-container").classList.add("d-none");
   document.getElementById("ajuste-container").classList.add("d-none");
   document.getElementById("inicio-upload").classList.remove("d-none");
+  document.getElementById("btn-upload").style.display = "inline-block";
   
   top1Prediction = null;
   base64Image = null;


### PR DESCRIPTION
## Summary
- Oculta completamente a seção inicial após o upload de imagem.
- Restabelece a seção e o botão de upload ao reiniciar.

## Testing
- `node --check script.js`
- `npm test` *(erro: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893dfd37448832ba4ae16bf0fdead93