### PR TITLE
Handle quiz fetch errors gracefully

### DIFF
--- a/quiz/quiz.js
+++ b/quiz/quiz.js
@@ -34,12 +34,24 @@ const classeEstilo = {
 let modoSelecionado = "aleatorio";
 
 async function loadQuiz() {
-  const response = await fetch("quiz_cases.json");
-  cases = await response.json();
-  aplicarFiltroOuAleatorio(modoSelecionado);
-  currentIndex = 0;
-  score = 0;
-  loadCase(currentIndex);
+  try {
+    const response = await fetch("quiz_cases.json");
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    cases = await response.json();
+    aplicarFiltroOuAleatorio(modoSelecionado);
+    currentIndex = 0;
+    score = 0;
+    loadCase(currentIndex);
+  } catch (error) {
+    const feedbackEl = document.getElementById("feedback");
+    if (feedbackEl) {
+      feedbackEl.innerText = "Erro ao carregar quiz.";
+      feedbackEl.classList.add("text-danger");
+    }
+    console.error("Erro ao carregar quiz:", error);
+  }
 }
 
 function aplicarFiltroOuAleatorio(modo = "aleatorio") {


### PR DESCRIPTION
## Summary
- handle errors when fetching quiz cases by wrapping fetch in try/catch
- inform the user via the feedback element if loading quiz data fails

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893e02bca28832ba6dd6c5ba6db620e