### PR TITLE
Centralize class list for quiz and validator

### DIFF
--- a/classes.json
+++ b/classes.json
@@ -1,0 +1,8 @@
+[
+  "normal",
+  "obstrucao",
+  "otite_media_aguda",
+  "otite_media_cronica",
+  "otite_externa_aguda",
+  "nao_otoscopica"
+]

--- a/quiz/index.html
+++ b/quiz/index.html
@@ -12,15 +12,9 @@
       <h2 class="fw-bold">🔬 Quiz Otoscópico</h2>
 
       <div class="d-flex justify-content-center my-3">
-<select id="modo-selecao" class="form-select w-50" onchange="mudarModo(this.value)">
-    <option value="aleatorio" selected>🔀 Modo Aleatório</option>
-    <option value="normal">🟢 Normal</option>
-    <option value="otite_media_aguda">🔴 Otite Média Aguda</option>
-    <option value="otite_media_cronica">🟡 Otite Média Crônica</option>
-    <option value="otite_externa_aguda">🔵 Otite Externa Aguda</option>
-    <option value="obstrucao">⚫ Obstrução do Canal</option>
-    <option value="nao_otoscopica">⚠️ Não é imagem otoscópica</option>
-  </select>
+      <select id="modo-selecao" class="form-select w-50" onchange="mudarModo(this.value)">
+        <option value="aleatorio" selected>🔀 Modo Aleatório</option>
+      </select>
 </div>
 
         <button

--- a/quiz/quiz.js
+++ b/quiz/quiz.js
@@ -3,14 +3,7 @@ let currentIndex = 0;
 let cases = [];
 let score = 0;
 
-const labels = [
-  "normal",
-  "otite_media_aguda",
-  "otite_media_cronica",
-  "otite_externa_aguda",
-  "obstrucao",
-  "nao_otoscopica"
-];
+let labels = [];
 
 const labelNames = {
   "normal": "Normal",
@@ -30,8 +23,41 @@ const classeEstilo = {
   "nao_otoscopica": "dark"
 };
 
+const labelEmojis = {
+  "normal": "🟢",
+  "otite_media_aguda": "🔴",
+  "otite_media_cronica": "🟡",
+  "otite_externa_aguda": "🔵",
+  "obstrucao": "⚫",
+  "nao_otoscopica": "⚠️",
+};
+
 // define modo inicial
 let modoSelecionado = "aleatorio";
+
+async function carregarClasses() {
+  try {
+    const response = await fetch("../classes.json");
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    labels = await response.json();
+    popularSelecao();
+  } catch (error) {
+    console.error("Erro ao carregar classes:", error);
+  }
+}
+
+function popularSelecao() {
+  const select = document.getElementById("modo-selecao");
+  if (!select) return;
+  labels.forEach(label => {
+    const option = document.createElement("option");
+    option.value = label;
+    option.textContent = `${labelEmojis[label] || ""} ${labelNames[label] || label}`;
+    select.appendChild(option);
+  });
+}
 
 async function loadQuiz() {
   try {
@@ -159,4 +185,7 @@ function modoRevisaoErros() {
   loadCase(currentIndex);
 }
 
-window.onload = loadQuiz;
+window.onload = async () => {
+  await carregarClasses();
+  await loadQuiz();
+};

--- a/validador_feedbacks.html
+++ b/validador_feedbacks.html
@@ -30,17 +30,27 @@
   <script>
     const imageGrid = document.getElementById('imageGrid');
     const feedbacks = [];
+    let CLASSES = [];
 
-    const CLASSES = [
-      "normal",
-      "obstrucao",
-      "otite_media_aguda",
-      "otite_media_cronica",
-      "otite_externa_aguda",
-      "nao_otoscopica"
-    ];
+    async function loadClasses() {
+      try {
+        const response = await fetch('classes.json');
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        CLASSES = await response.json();
+      } catch (error) {
+        console.error('Erro ao carregar classes:', error);
+      }
+    }
+
+    loadClasses();
 
     document.getElementById('imageUploader').addEventListener('change', (e) => {
+      if (!CLASSES.length) {
+        alert('Lista de classes ainda não carregada.');
+        return;
+      }
       const files = Array.from(e.target.files);
       imageGrid.innerHTML = '';
       feedbacks.length = 0;


### PR DESCRIPTION
## Summary
- add `classes.json` with unified class names
- quiz loads class list to build mode selector and answer options dynamically
- validation tool fetches the same list for its dropdowns

## Testing
- `node --check quiz/quiz.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893fbba4c38832bba71627640f529c2