### PR TITLE
Centralize probability bar labels

### DIFF
--- a/style.css
+++ b/style.css
@@ -114,6 +114,12 @@ h1, .card-title {
   left: 0;
   color: #000;
   background-color: rgba(255, 255, 255, 0.8);
+  top: 50%;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .bar-fill {


### PR DESCRIPTION
## Summary
- center bar label vertically
- prevent label overflow with ellipsis

## Testing
- `npm test` *(fails: package.json not found)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689405ee5e44832ba2ff2425f0f85596