### PR TITLE
Generate clinical symptom checkboxes dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,11 +60,7 @@
       <div class="card-body">
         <h5 class="card-title">📋 Sintomas Clínicos</h5>
         <form id="sintomas-form">
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="exposicao_agua" id="agua"><label class="form-check-label" for="agua">Exposição à água</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="otalgia_tracao" id="tracao"><label class="form-check-label" for="tracao">Otalgia à tração</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="febre" id="febre"><label class="form-check-label" for="febre">Febre</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="plenitude" id="plenitude"><label class="form-check-label" for="plenitude">Plenitude Aural</label></div>
-          <div class="form-check"><input class="form-check-input" type="checkbox" value="hipoacusia" id="hipoacusia"><label class="form-check-label" for="hipoacusia">Hipoacusia</label></div>
+          <div id="checkbox-container"></div>
           <button type="button" class="btn btn-warning mt-3" id="ajustarBtn">🔁 Recalcular com dados clínicos</button>
         </form>
       </div>
@@ -119,8 +115,8 @@
 
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="script.js"></script>
   <script src="ajuste_clinico.js"></script>
-  
+  <script src="script.js"></script>
+
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,44 @@ const labelContainer = document.getElementById("label-container");
 const preview = document.getElementById("preview");
 const classifyBtn = document.getElementById("classifyBtn");
 const loadingIndicator = document.getElementById("loadingIndicator");
+const checkboxContainer = document.getElementById("checkbox-container");
+
+// Gerar dinamicamente os checkboxes com base em impactoSintomas
+const sintomasLabels = {
+  exposicao_agua: "Exposição à água",
+  otalgia_tracao: "Otalgia à tração",
+  febre: "Febre",
+  plenitude: "Plenitude Aural",
+  hipoacusia: "Hipoacusia",
+  otalgia: "Otalgia",
+  otorreia: "Otorreia",
+  prurido: "Prurido",
+  inicio_agudo: "Início agudo",
+  duracao_cronica: "Duração crônica",
+  tinnitus: "Tinnitus",
+  vertigem: "Vertigem",
+  tosse: "Tosse"
+};
+
+Object.keys(impactoSintomas).forEach(chave => {
+  const wrapper = document.createElement("div");
+  wrapper.className = "form-check";
+
+  const input = document.createElement("input");
+  input.className = "form-check-input";
+  input.type = "checkbox";
+  input.value = chave;
+  input.id = chave;
+
+  const label = document.createElement("label");
+  label.className = "form-check-label";
+  label.htmlFor = chave;
+  label.textContent = sintomasLabels[chave] || chave;
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(label);
+  checkboxContainer.appendChild(wrapper);
+});
 
 classifyBtn.disabled = true;
 


### PR DESCRIPTION
## Summary
- Dynamically create clinical symptom checkboxes from `impactoSintomas` so all current and future keys are covered automatically.
- Provide human-friendly labels for symptoms and ensure checkbox generation occurs before model classification.
- Load `ajuste_clinico.js` before `script.js` so the symptom impact map is available during initialization.

## Testing
- `node --check script.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894078639e8832ba1a036c999130079