### PR TITLE
Reorganiza ajuste clínico no resultado

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,25 +55,6 @@
       </div>
     </div>
 
-    <!-- Sintomas Clínicos -->
-    <div id="clinico-container" class="card mt-3 d-none">
-      <div class="card-body">
-        <h5 class="card-title">📋 Sintomas Clínicos</h5>
-        <form id="sintomas-form">
-          <div id="checkbox-container"></div>
-          <button type="button" class="btn btn-warning mt-3" id="ajustarBtn">🔁 Recalcular com dados clínicos</button>
-        </form>
-      </div>
-    </div>
-
-
-    <!-- Resultado Ajustado -->
-    <div id="ajuste-container" class="text-center mt-3 d-none">
-      <h5>Pós-ajuste com dados clínicos:</h5>
-      <div id="ajuste-labels" class="fw-bold"></div>
-      <button class="btn btn-outline-primary mt-2" id="exportAjustadoBtn">📤 Exportar JSON Ajustado</button>
-    </div>
-
     <!-- Resultado da Classificação -->
     <div class="card shadow d-none" id="resultado-area">
       <img id="preview" src="#" class="card-img-top" alt="Pré-visualização" style="max-height: 300px; object-fit: contain;" />
@@ -86,14 +67,17 @@
           <div class="card-body">
             <h5 class="card-title">📋 Sintomas Clínicos</h5>
             <form id="sintomas-form">
-              <div class="form-check"><input class="form-check-input" type="checkbox" value="exposicao_agua" id="agua"><label class="form-check-label" for="agua">Exposição à água</label></div>
-              <div class="form-check"><input class="form-check-input" type="checkbox" value="otalgia_tracao" id="tracao"><label class="form-check-label" for="tracao">Otalgia à tração</label></div>
-              <div class="form-check"><input class="form-check-input" type="checkbox" value="febre" id="febre"><label class="form-check-label" for="febre">Febre</label></div>
-              <div class="form-check"><input class="form-check-input" type="checkbox" value="plenitude" id="plenitude"><label class="form-check-label" for="plenitude">Plenitude Aural</label></div>
-              <div class="form-check"><input class="form-check-input" type="checkbox" value="hipoacusia" id="hipoacusia"><label class="form-check-label" for="hipoacusia">Hipoacusia</label></div>
+              <div id="checkbox-container"></div>
               <button type="button" class="btn btn-warning mt-3" id="ajustarBtn">🔁 Recalcular com dados clínicos</button>
             </form>
           </div>
+        </div>
+
+        <!-- Resultado Ajustado -->
+        <div id="ajuste-container" class="text-center mt-3 d-none">
+          <h5>Pós-ajuste com dados clínicos:</h5>
+          <div id="ajuste-labels" class="fw-bold"></div>
+          <button class="btn btn-outline-primary mt-2" id="exportAjustadoBtn">📤 Exportar JSON Ajustado</button>
         </div>
 
         <!-- Feedback simples -->


### PR DESCRIPTION
## Summary
- Move ajuste-container para imediatamente após o clinico-container dentro de resultado-area

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('index.html','utf-8');const posClin=html.indexOf('id=\"clinico-container\"');const posAj=html.indexOf('id=\"ajuste-container\"');console.log('order',posClin,posAj,posClin<posAj);const labelExists=html.includes('id=\"label-container\"');const script=fs.readFileSync('script.js','utf-8');const scrollCall=/document.getElementById\(\"label-container\"\)\.scrollIntoView/.test(script);console.log('labelExists',labelExists,'scrollCall',scrollCall);"`


------
https://chatgpt.com/codex/tasks/task_e_6894102addac832b98af11b2473ea03b