### PR TITLE
Alinha checkboxes de sintomas aos slugs de impacto

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,60 @@
           <div class="card-body">
             <h5 class="card-title">📋 Sintomas Clínicos</h5>
             <form id="sintomas-form">
-              <div id="checkbox-container"></div>
+              <div id="checkbox-container">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="exposicao_agua" value="exposicao_agua">
+                  <label class="form-check-label" for="exposicao_agua">Exposição à água</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="otalgia_tracao" value="otalgia_tracao">
+                  <label class="form-check-label" for="otalgia_tracao">Otalgia à tração</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="febre" value="febre">
+                  <label class="form-check-label" for="febre">Febre</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="plenitude" value="plenitude">
+                  <label class="form-check-label" for="plenitude">Plenitude Aural</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="hipoacusia" value="hipoacusia">
+                  <label class="form-check-label" for="hipoacusia">Hipoacusia</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="otalgia" value="otalgia">
+                  <label class="form-check-label" for="otalgia">Otalgia</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="otorreia" value="otorreia">
+                  <label class="form-check-label" for="otorreia">Otorreia</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="prurido" value="prurido">
+                  <label class="form-check-label" for="prurido">Prurido</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="inicio_agudo" value="inicio_agudo">
+                  <label class="form-check-label" for="inicio_agudo">Início agudo</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="duracao_cronica" value="duracao_cronica">
+                  <label class="form-check-label" for="duracao_cronica">Duração crônica</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="tinnitus" value="tinnitus">
+                  <label class="form-check-label" for="tinnitus">Tinnitus</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="vertigem" value="vertigem">
+                  <label class="form-check-label" for="vertigem">Vertigem</label>
+                </div>
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="tosse" value="tosse">
+                  <label class="form-check-label" for="tosse">Tosse</label>
+                </div>
+              </div>
               <button type="button" class="btn btn-warning mt-3" id="ajustarBtn">🔁 Recalcular com dados clínicos</button>
             </form>
           </div>

--- a/script.js
+++ b/script.js
@@ -13,7 +13,6 @@ const labelContainer = document.getElementById("label-container");
 const preview = document.getElementById("preview");
 const classifyBtn = document.getElementById("classifyBtn");
 const loadingIndicator = document.getElementById("loadingIndicator");
-const checkboxContainer = document.getElementById("checkbox-container");
 
 const classLabels = {
   otite_media_aguda: "Otite Média Aguda",
@@ -24,43 +23,6 @@ const classLabels = {
   normal: "Normal"
 };
 
-
-// Gerar dinamicamente os checkboxes com base em impactoSintomas
-const sintomasLabels = {
-  exposicao_agua: "Exposição à água",
-  otalgia_tracao: "Otalgia à tração",
-  febre: "Febre",
-  plenitude: "Plenitude Aural",
-  hipoacusia: "Hipoacusia",
-  otalgia: "Otalgia",
-  otorreia: "Otorreia",
-  prurido: "Prurido",
-  inicio_agudo: "Início agudo",
-  duracao_cronica: "Duração crônica",
-  tinnitus: "Tinnitus",
-  vertigem: "Vertigem",
-  tosse: "Tosse"
-};
-
-Object.keys(impactoSintomas).forEach(chave => {
-  const wrapper = document.createElement("div");
-  wrapper.className = "form-check";
-
-  const input = document.createElement("input");
-  input.className = "form-check-input";
-  input.type = "checkbox";
-  input.value = chave;
-  input.id = chave;
-
-  const label = document.createElement("label");
-  label.className = "form-check-label";
-  label.htmlFor = chave;
-  label.textContent = sintomasLabels[chave] || chave;
-
-  wrapper.appendChild(input);
-  wrapper.appendChild(label);
-  checkboxContainer.appendChild(wrapper);
-});
 
 classifyBtn.disabled = true;
 


### PR DESCRIPTION
## Summary
- Define checkboxes de sintomas diretamente em `index.html` usando `id` e `value` iguais aos slugs de `impactoSintomas`
- Remove geração dinâmica desses checkboxes e referências a IDs no `script.js`

## Testing
- `node --check script.js`
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894162c8ee0832b90e196dc7c8eaca3