### PR TITLE
Add clinical data toggle and reorganize feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,34 @@
         <h5 class="card-title text-center">Resultado da Classificação</h5>
         <div id="label-container" class="text-center fw-bold mb-3"></div>
 
+        <!-- Feedback simples -->
+        <div id="feedbackSection" class="text-center mt-3 d-none">
+          <p class="fw-bold">Esse resultado está correto?</p>
+          <button class="btn btn-success me-2" id="feedback-yes">✔ Sim</button>
+          <button class="btn btn-danger" id="feedback-no">✖ Não</button>
+        </div>
+
+        <!-- Correção de classe -->
+        <div id="correctionSection" class="text-center mt-2 d-none">
+          <p>Selecione a classe correta:</p>
+          <select id="correctionSelect" class="form-select w-auto d-inline-block">
+            <option value="">Escolher...</option>
+            <option value="normal">Normal</option>
+            <option value="otite_media_aguda">Otite Média Aguda</option>
+            <option value="otite_media_cronica">Otite Média Crônica</option>
+            <option value="otite_externa_aguda">Otite Externa Aguda</option>
+            <option value="obstrucao">Obstrução do Canal</option>
+            <option value="nao_otoscopica">Não é imagem otoscópica</option>
+          </select>
+          <button class="btn btn-outline-primary ms-2" id="exportFeedbackBtn">📤 Exportar Feedback</button>
+        </div>
+
+        <!-- Pergunta sobre dados clínicos -->
+        <div id="clinico-toggle" class="text-center mt-3 d-none">
+          <p>Deseja incluir dados clínicos?</p>
+          <button class="btn btn-warning" id="toggleClinicoBtn">Adicionar dados clínicos</button>
+        </div>
+
         <!-- Sintomas Clínicos -->
         <div id="clinico-container" class="card mt-3 d-none">
           <div class="card-body">
@@ -131,28 +159,6 @@
           <h5>Pós-ajuste com dados clínicos:</h5>
           <div id="ajuste-labels" class="fw-bold"></div>
           <button class="btn btn-outline-primary mt-2" id="exportAjustadoBtn">📤 Exportar JSON Ajustado</button>
-        </div>
-
-        <!-- Feedback simples -->
-        <div id="feedbackSection" class="text-center mt-3 d-none">
-          <p class="fw-bold">Esse resultado está correto?</p>
-          <button class="btn btn-success me-2" id="feedback-yes">✔ Sim</button>
-          <button class="btn btn-danger" id="feedback-no">✖ Não</button>
-        </div>
-
-        <!-- Correção de classe -->
-        <div id="correctionSection" class="text-center mt-2 d-none">
-          <p>Selecione a classe correta:</p>
-          <select id="correctionSelect" class="form-select w-auto d-inline-block">
-            <option value="">Escolher...</option>
-            <option value="normal">Normal</option>
-            <option value="otite_media_aguda">Otite Média Aguda</option>
-            <option value="otite_media_cronica">Otite Média Crônica</option>
-            <option value="otite_externa_aguda">Otite Externa Aguda</option>
-            <option value="obstrucao">Obstrução do Canal</option>
-            <option value="nao_otoscopica">Não é imagem otoscópica</option>
-          </select>
-          <button class="btn btn-outline-primary ms-2" id="exportFeedbackBtn">📤 Exportar Feedback</button>
         </div>
 
         <!-- Reiniciar -->

--- a/script.js
+++ b/script.js
@@ -56,6 +56,7 @@ document.getElementById("imageUpload").addEventListener("change", event => {
     document.getElementById("feedbackSection").classList.add("d-none");
     document.getElementById("correctionSection").classList.add("d-none");
     document.getElementById("clinico-container").classList.add("d-none");
+    document.getElementById("clinico-toggle").classList.add("d-none");
     document.getElementById("resultado-area").classList.remove("d-none");
     document.getElementById("btn-upload").style.display = "none";
     document.getElementById("inicio-upload").classList.add("d-none");
@@ -100,7 +101,8 @@ classifyBtn.addEventListener("click", async () => {
     document.getElementById("feedbackSection").classList.remove("d-none");
     document.getElementById("correctionSection").classList.add("d-none");
     document.getElementById("correctionSelect").value = "";
-    document.getElementById("clinico-container").classList.remove("d-none");
+    document.getElementById("clinico-toggle").classList.remove("d-none");
+    document.getElementById("clinico-container").classList.add("d-none");
 
     document.getElementById("label-container").scrollIntoView({ behavior: "smooth" });
   } catch (error) {
@@ -144,6 +146,20 @@ document.getElementById("exportFeedbackBtn").addEventListener("click", () => {
   a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+});
+
+// Mostrar/ocultar card clínico
+document.getElementById("toggleClinicoBtn").addEventListener("click", () => {
+  const clinico = document.getElementById("clinico-container");
+  const toggle = document.getElementById("clinico-toggle");
+  const oculto = clinico.classList.contains("d-none");
+  if (oculto) {
+    clinico.classList.remove("d-none");
+    toggle.classList.add("d-none");
+  } else {
+    clinico.classList.add("d-none");
+    toggle.classList.remove("d-none");
+  }
 });
 
 // Recalcular com sintomas clínicos
@@ -210,6 +226,7 @@ function reiniciar() {
   document.getElementById("correctionSection").classList.add("d-none");
   document.getElementById("resultado-area").classList.add("d-none");
   document.getElementById("clinico-container").classList.add("d-none");
+  document.getElementById("clinico-toggle").classList.add("d-none");
   document.getElementById("ajuste-container").classList.add("d-none");
   document.getElementById("inicio-upload").classList.remove("d-none");
   document.getElementById("btn-upload").style.display = "inline-block";


### PR DESCRIPTION
## Summary
- Move feedback and correction sections to follow predictions and precede clinical data
- Introduce toggle prompt for adding clinical data and show it after classification
- Add button logic and reset handling for clinical data toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68942305d408832bb193d5ac2cd61122