### PR TITLE
Adicionar opção "Ausência de sintomas"

### DIFF
--- a/ajuste_clinico.js
+++ b/ajuste_clinico.js
@@ -1,6 +1,7 @@
 // ajuste_clinico.js
 
 const impactoSintomas = {
+  sem_sintomas: { otite_media_aguda: -0.20, otite_media_cronica: -0.20, otite_externa_aguda: -0.20, obstrucao: -0.20, normal: 0.20 },
   febre: { otite_media_aguda: 0.25, otite_media_cronica: -0.15, otite_externa_aguda: -0.10, obstrucao: -0.05, normal: -0.10 },
   otalgia: { otite_media_aguda: 0.20, otite_media_cronica: -0.20, otite_externa_aguda: 0.30, obstrucao: 0.10, normal: -0.20 },
   otalgia_tracao: { otite_media_aguda: -0.25, otite_media_cronica: -0.20, otite_externa_aguda: 0.30, obstrucao: -0.10, normal: -0.20 },
@@ -29,7 +30,10 @@ window.ajustarComSintomas = function (predicoes, sintomasSelecionados) {
     "otite externa": "otite_externa_aguda",
     "obstrução": "obstrucao",
     "obstrucao": "obstrucao",
-    "normal": "normal"
+    "normal": "normal",
+      "sem sintomas": "sem_sintomas",
+      "ausencia de sintomas": "sem_sintomas",
+      "ausência de sintomas": "sem_sintomas"
   };
 
   sintomasSelecionados.forEach(sintoma => {

--- a/index.html
+++ b/index.html
@@ -97,6 +97,10 @@
             <form id="sintomas-form">
               <div id="checkbox-container">
                 <div class="form-check">
+                  <input class="form-check-input" type="checkbox" id="sem_sintomas" value="sem_sintomas">
+                  <label class="form-check-label" for="sem_sintomas">Ausência de sintomas</label>
+                </div>
+                <div class="form-check">
                   <input class="form-check-input" type="checkbox" id="exposicao_agua" value="exposicao_agua">
                   <label class="form-check-label" for="exposicao_agua">Exposição à água</label>
                 </div>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,26 @@ const classLabels = {
   nao_otoscopica: "Não é imagem otoscópica",
   normal: "Normal"
 };
+const semSintomasCheckbox = document.getElementById("sem_sintomas");
+const outrosSintomas = document.querySelectorAll("#sintomas-form input[type='checkbox']:not(#sem_sintomas)");
+if (semSintomasCheckbox) {
+  semSintomasCheckbox.addEventListener("change", () => {
+    if (semSintomasCheckbox.checked) {
+      outrosSintomas.forEach(cb => { cb.checked = false; cb.disabled = true; });
+    } else {
+      outrosSintomas.forEach(cb => cb.disabled = false);
+    }
+  });
+  outrosSintomas.forEach(cb => {
+    cb.addEventListener("change", () => {
+      if (cb.checked) {
+        semSintomasCheckbox.checked = false;
+        semSintomasCheckbox.dispatchEvent(new Event("change"));
+      }
+    });
+  });
+}
+
 
 
 classifyBtn.disabled = true;
@@ -185,6 +205,7 @@ document.getElementById("ajustarBtn").addEventListener("click", async () => {
 
   document.getElementById("ajuste-container").classList.remove("d-none");
   document.querySelectorAll("#sintomas-form input").forEach(cb => cb.checked = false);
+  if (semSintomasCheckbox) semSintomasCheckbox.dispatchEvent(new Event("change"));
 });
 
 // Exportar resultado ajustado
@@ -235,6 +256,7 @@ function reiniciar() {
   base64Image = null;
   document.getElementById("ajuste-labels").innerHTML = "";
   document.querySelectorAll("#sintomas-form input").forEach(cb => cb.checked = false);
+  if (semSintomasCheckbox) semSintomasCheckbox.dispatchEvent(new Event("change"));
 }
 
 // Cores para a barra de probabilidade


### PR DESCRIPTION
## Summary
- Adiciona checkbox **Ausência de sintomas** ao formulário clínico
- Introduz regra `sem_sintomas` em `impactoSintomas` e nos aliases
- Garante exclusividade ao selecionar ausência de sintomas, limpando e desabilitando os demais checkboxes

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895675add5c832b80c9c7c7ce6aa3de