### PR TITLE
Add Jest tests for symptom adjustment and feedback flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ frontend_web/model_tfjs/
 
 modelo_retreinado/*.keras
 modelo_retreinado/**/*.h5
+
+# Node dependencies
+node_modules/

--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ A página principal (`index.html`) é composta por:
 3. Clique em **Classificar Imagem** para que o modelo processe a foto.
 4. Consulte o resultado com as probabilidades no cartão central.
 5. Opcionalmente utilize **Imprimir Resultado** para gerar um PDF/impresso ou **Reset** para limpar a tela.
+
+## 🧪 Testes
+
+Este projeto utiliza [Jest](https://jestjs.io/) para testes unitários e de integração.
+
+Para instalar as dependências e executar a suíte de testes, utilize:
+
+```bash
+npm install
+npm test
+```

--- a/__tests__/ajuste_clinico.test.js
+++ b/__tests__/ajuste_clinico.test.js
@@ -1,0 +1,32 @@
+const { ajustarComSintomas } = require('../ajuste_clinico.js');
+
+describe('ajustarComSintomas', () => {
+  const basePredicoes = [
+    { className: 'otite_media_aguda', probability: 0.5 },
+    { className: 'normal', probability: 0.5 },
+  ];
+
+  test('mantém probabilidades originais sem sintomas', () => {
+    const result = ajustarComSintomas(basePredicoes, []);
+    expect(result).toEqual([
+      { classe: 'otite_media_aguda', original: 0.5, ajustado: 0.5 },
+      { classe: 'normal', original: 0.5, ajustado: 0.5 },
+    ]);
+  });
+
+  test('ajusta probabilidades com sintoma "febre"', () => {
+    const result = ajustarComSintomas(basePredicoes, ['febre']);
+    const otite = result.find(r => r.classe === 'otite_media_aguda');
+    const normal = result.find(r => r.classe === 'normal');
+    expect(otite.ajustado).toBeCloseTo(0.6522, 4);
+    expect(normal.ajustado).toBeCloseTo(0.3478, 4);
+  });
+
+  test('trata "sem sintomas" corretamente', () => {
+    const result = ajustarComSintomas(basePredicoes, ['sem_sintomas']);
+    expect(result).toEqual([
+      { classe: 'otite_media_aguda', original: 0.5, ajustado: 0.3 },
+      { classe: 'normal', original: 0.5, ajustado: 0.7 },
+    ]);
+  });
+});

--- a/__tests__/feedback.integration.test.js
+++ b/__tests__/feedback.integration.test.js
@@ -1,0 +1,36 @@
+const { saveFeedback, modoRevisaoErros } = require('../quiz/quiz.js');
+
+describe('fluxo de feedback', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  test('saveFeedback registra dados no localStorage', () => {
+    const spy = jest.spyOn(Storage.prototype, 'setItem');
+    saveFeedback('img.png', 'pred', 'resp', 'real');
+    expect(spy).toHaveBeenCalled();
+    const historico = JSON.parse(localStorage.getItem('feedbacks'));
+    expect(historico).toHaveLength(1);
+    expect(historico[0]).toMatchObject({
+      filename: 'img.png',
+      predicted: 'pred',
+      user_answer: 'resp',
+      real_label: 'real'
+    });
+  });
+
+  test('modoRevisaoErros avisa quando não há erros', () => {
+    const registro = {
+      filename: 'img.png',
+      predicted: 'a',
+      user_answer: 'a',
+      real_label: 'a',
+      timestamp: new Date().toISOString()
+    };
+    localStorage.setItem('feedbacks', JSON.stringify([registro]));
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    modoRevisaoErros();
+    expect(alertSpy).toHaveBeenCalledWith('Todos os casos anteriores estavam corretos! Parabéns!');
+  });
+});

--- a/ajuste_clinico.js
+++ b/ajuste_clinico.js
@@ -17,7 +17,7 @@ const impactoSintomas = {
   tosse: { obstrucao: 0.05 }
 };
 
-window.ajustarComSintomas = function (predicoes, sintomasSelecionados) {
+function ajustarComSintomas(predicoes, sintomasSelecionados) {
   const ajustes = {};
   const aliases = {
     "não é imagem otoscópica": "nao_otoscopica",
@@ -61,3 +61,8 @@ window.ajustarComSintomas = function (predicoes, sintomasSelecionados) {
     ajustado: +(p.bruto / somaBruto).toFixed(4)
   }));
 };
+
+window.ajustarComSintomas = ajustarComSintomas;
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { ajustarComSintomas };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "protto",
+  "version": "1.0.0",
+  "description": "This folder contains a simple HTML page that allows you to load a TensorFlow.js model and run predictions on otoscopic images in the browser.",
+  "main": "ajuste_clinico.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.5",
+    "jest-environment-jsdom": "^30.0.5"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/quiz/quiz.js
+++ b/quiz/quiz.js
@@ -189,3 +189,7 @@ window.onload = async () => {
   await carregarClasses();
   await loadQuiz();
 };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { saveFeedback, modoRevisaoErros };
+}


### PR DESCRIPTION
## Summary
- configure Jest test environment
- expose clinical adjustment and quiz feedback functions for testing
- add unit and integration tests plus instructions for running them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68957d6202f4832bba80ded0f27d25ed