### PR TITLE
Style quiz image with responsive class

### DIFF
--- a/quiz/index.html
+++ b/quiz/index.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <title>Quiz Otoscópico 🧠</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="../style.css" rel="stylesheet" />
 </head>
 <body class="bg-light">
   <div class="d-flex justify-content-center">
@@ -27,14 +28,13 @@
         <p class="text-muted">Valide sua acurácia em diagnósticos otoscópicos</p>
       </div>
 
-      <div class="card shadow mx-auto" style="max-width: 600px;">
-        <img
-          id="quiz-image"
-          src=""
-          class="card-img-top"
-          alt="Imagem Otoscópica"
-          style="max-height: 400px; object-fit: contain;"
-        />
+        <div class="card shadow mx-auto" style="max-width: 600px;">
+          <img
+            id="quiz-image"
+            src=""
+            class="card-img-top img-fluid quiz-img"
+            alt="Imagem Otoscópica"
+          />
         <div class="card-body">
           <h5 class="card-title text-center">Qual seu diagnóstico?</h5>
 

--- a/style.css
+++ b/style.css
@@ -80,6 +80,13 @@ h1, .card-title {
   display: block;
 }
 
+/* ---------- QUIZ IMAGE ---------- */
+.quiz-img {
+  max-height: 250px;
+  width: 100%;
+  object-fit: contain;
+}
+
 /* ---------- CARD GERAL ---------- */
 .card {
   border-radius: 16px;


### PR DESCRIPTION
## Summary
- Add `.quiz-img` CSS class with 250px max height and full-width layout
- Apply new responsive image class in quiz and remove inline styles
- Link shared stylesheet to quiz page for consistent styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995c09c780832b9a8fe47ceca006e0