### PR TITLE
Improve quiz interaction with button states and progress bar

### DIFF
--- a/quiz/index.html
+++ b/quiz/index.html
@@ -40,6 +40,17 @@
 
           <div id="options" class="btn-group-vertical w-100 my-3"></div>
 
+          <div class="progress my-2">
+            <div
+              id="progress-bar"
+              class="progress-bar progress-bar-striped progress-bar-animated"
+              role="progressbar"
+              style="width: 0%"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            ></div>
+          </div>
+
           <div class="text-center">
             <p id="feedback" class="fw-bold fs-5"></p>
             <p id="progresso" class="text-muted"></p>

--- a/quiz/quiz.js
+++ b/quiz/quiz.js
@@ -109,7 +109,8 @@ function loadCase(index) {
 
   labels.forEach(label => {
     const btn = document.createElement("button");
-    btn.className = `btn btn-outline-${classeEstilo[label]} mb-2`;
+    btn.className = `btn btn-outline-${classeEstilo[label]} mb-2 option-btn`;
+    btn.dataset.label = label;
     btn.innerText = labelNames[label] || label;
     btn.onclick = () => validateAnswer(label, caso);
     container.appendChild(btn);
@@ -117,11 +118,32 @@ function loadCase(index) {
 
   document.getElementById("feedback").innerText = "";
   document.getElementById("progresso").innerText = `Caso ${index + 1} de ${cases.length}`;
+
+  const progressBar = document.getElementById("progress-bar");
+  if (progressBar) {
+    const percent = (index / cases.length) * 100;
+    progressBar.style.width = `${percent}%`;
+    progressBar.setAttribute("aria-valuenow", percent);
+  }
 }
 
 function validateAnswer(resposta, caso) {
   const certo = resposta === caso.true_label;
   if (certo) score++;
+
+  const buttons = document.querySelectorAll("#options .option-btn");
+  buttons.forEach(btn => {
+    btn.disabled = true;
+    const lbl = btn.dataset.label;
+    btn.className = `btn mb-2 option-btn`;
+    if (lbl === caso.true_label) {
+      btn.classList.add("btn-success");
+    } else if (lbl === resposta) {
+      btn.classList.add("btn-danger");
+    } else {
+      btn.classList.add(`btn-outline-${classeEstilo[lbl]}`);
+    }
+  });
 
   const feedback = certo
     ? "✅ Correto!"
@@ -135,6 +157,11 @@ function validateAnswer(resposta, caso) {
     if (currentIndex < cases.length) {
       loadCase(currentIndex);
     } else {
+      const progressBar = document.getElementById("progress-bar");
+      if (progressBar) {
+        progressBar.style.width = "100%";
+        progressBar.setAttribute("aria-valuenow", 100);
+      }
       alert(`🎉 Fim do quiz! Você acertou ${score} de ${cases.length}.`);
     }
   }, 2000);


### PR DESCRIPTION
## Summary
- Tag option buttons and update progress bar each question
- Disable answer buttons on selection and highlight correct/incorrect choices
- Add animated progress bar to quiz interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995c1207f0832bb9264ab95a29ff7a