### PR TITLE
Add manual next-step flow and score summary to quiz

### DIFF
--- a/quiz/index.html
+++ b/quiz/index.html
@@ -54,7 +54,10 @@
           <div class="text-center">
             <p id="feedback" class="fw-bold fs-5"></p>
             <p id="progresso" class="text-muted"></p>
+            <p id="summary" class="fw-bold fs-5"></p>
           </div>
+
+          <button id="next-btn" class="btn btn-primary w-100 my-2" style="display: none;" onclick="nextCase()">Próximo</button>
 
           <div class="d-flex justify-content-between">
             <button class="btn btn-outline-success w-50 me-2" onclick="exportarFeedbacks()">📤 Exportar Feedbacks</button>

--- a/quiz/quiz.js
+++ b/quiz/quiz.js
@@ -104,6 +104,11 @@ function loadCase(index) {
   const caso = cases[index];
   document.getElementById("quiz-image").src = "data:image/jpeg;base64," + caso.img_base64;
 
+  const nextBtn = document.getElementById("next-btn");
+  if (nextBtn) nextBtn.style.display = "none";
+  const summary = document.getElementById("summary");
+  if (summary) summary.innerText = "";
+
   const container = document.getElementById("options");
   container.innerHTML = "";
 
@@ -152,19 +157,27 @@ function validateAnswer(resposta, caso) {
 
   saveFeedback(caso.filename, caso.predicted, resposta, caso.true_label);
 
-  setTimeout(() => {
-    currentIndex++;
-    if (currentIndex < cases.length) {
-      loadCase(currentIndex);
-    } else {
-      const progressBar = document.getElementById("progress-bar");
-      if (progressBar) {
-        progressBar.style.width = "100%";
-        progressBar.setAttribute("aria-valuenow", 100);
-      }
-      alert(`🎉 Fim do quiz! Você acertou ${score} de ${cases.length}.`);
+  const nextBtn = document.getElementById("next-btn");
+  if (nextBtn) nextBtn.style.display = "block";
+}
+
+function nextCase() {
+  currentIndex++;
+  if (currentIndex < cases.length) {
+    loadCase(currentIndex);
+  } else {
+    const progressBar = document.getElementById("progress-bar");
+    if (progressBar) {
+      progressBar.style.width = "100%";
+      progressBar.setAttribute("aria-valuenow", 100);
     }
-  }, 2000);
+    const summary = document.getElementById("summary");
+    if (summary) {
+      summary.innerText = `🎉 Fim do quiz! Você acertou ${score} de ${cases.length}.`;
+    }
+    const nextBtn = document.getElementById("next-btn");
+    if (nextBtn) nextBtn.style.display = "none";
+  }
 }
 
 function saveFeedback(nome, predicted, resposta, real) {


### PR DESCRIPTION
## Summary
- add hidden "Próximo" button and summary area to quiz page
- replace timed auto-advance with manual next step and inline score summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a69252834832bb53fa029a7d9b92a