### PR TITLE
Enable keyboard navigation for quiz options

### DIFF
--- a/quiz/quiz.js
+++ b/quiz/quiz.js
@@ -107,12 +107,13 @@ function loadCase(index) {
   const container = document.getElementById("options");
   container.innerHTML = "";
 
-  labels.forEach(label => {
+  labels.forEach((label, idx) => {
     const btn = document.createElement("button");
     btn.className = `btn btn-outline-${classeEstilo[label]} mb-2 option-btn`;
     btn.dataset.label = label;
     btn.innerText = labelNames[label] || label;
     btn.onclick = () => validateAnswer(label, caso);
+    btn.tabIndex = idx + 1;
     container.appendChild(btn);
   });
 
@@ -126,6 +127,21 @@ function loadCase(index) {
     progressBar.setAttribute("aria-valuenow", percent);
   }
 }
+
+function handleKeyup(event) {
+  const options = document.querySelectorAll('#options .option-btn');
+  const num = parseInt(event.key, 10);
+  if (num >= 1 && num <= options.length) {
+    options[num - 1].click();
+  } else if (event.key === 'Enter') {
+    const focused = document.activeElement;
+    if (focused && focused.classList.contains('option-btn')) {
+      focused.click();
+    }
+  }
+}
+
+document.addEventListener('keyup', handleKeyup);
 
 function validateAnswer(resposta, caso) {
   const certo = resposta === caso.true_label;

--- a/style.css
+++ b/style.css
@@ -236,3 +236,9 @@ button.btn-lg, .btn-lg {
     font-size: 1rem;
   }
 }
+
+/* ---------- QUIZ OPTION FOCUS ---------- */
+#options .option-btn:focus {
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.5);
+  outline: none;
+}


### PR DESCRIPTION
## Summary
- Assign tabindex to dynamically generated quiz option buttons
- Trigger answer validation with numeric and Enter key presses
- Highlight focused quiz options for better accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a69d613ec832ba8812931290b1bf5